### PR TITLE
Rename conference talks link to talks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,6 @@ tabs = [
     {name="people",path="/people/",nav=true},
     {name="blog",path="http://blog.nilenso.com/",nav=true},
     {name="alumni",path="/alumni/",nav=false},
-    {name="conference talks",path="/talks/",nav=false},
+    {name="talks",path="/talks/",nav=false},
     {name="contact",path="#contact",nav=true},
 ]


### PR DESCRIPTION
[Story](https://app.shortcut.com/nilenso/story/1408/rename-conference-talks-to-talks-in-the-mobile-menu)

The mobile menu has a link called `conference talks` instead of `talks`, renaming.