### PR TITLE
Add meta data information to improve website SEO

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="description" content="boutique technology consultancy">
+    <meta name="description" content="nilenso is a boutique technology consultancy based in India and Canada. We build thoughtful, well-crafted products for your organization.">
     <meta name="keyword" content="nilenso, technology consultancy, software consultancy, coop, clojure, functional programming, backend development, health care software, Fintech, last mile delivery software">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{% block title %}nilenso{% endblock %}</title>

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="description" content="">
+    <meta name="description" content="boutique technology consultancy">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{% block title %}nilenso{% endblock %}</title>
     {% block head %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
             <div class="hidden md:flex items-center justify-between">
                 <a href="/">
                     <figure>
-                        <img src="/images/svg/logo.svg" alt="Logo" class="w-4/5">
+                        <img src="/images/svg/logo.svg" alt="nilenso" class="w-4/5">
                     </figure>
                 </a>
                 <ul class="flex">

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="description" content="boutique technology consultancy">
+    <meta name="keyword" content="nilenso, technology consultancy, software consultancy, coop, clojure, functional programming, backend development, health care software, Fintech, last mile delivery software">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{% block title %}nilenso{% endblock %}</title>
     {% block head %}


### PR DESCRIPTION
**Because**
- nilenso website has poor visibility due to bad SEO

**This addresses**
- Add meaningful `alt` test for our logo
- Add a one line meta description for our website
- Add meta keyword tag which contains all the are relevant keywords to show up nilenso