### PR TITLE
Fix double period typo

### DIFF
--- a/content/people/sezal-jain.md
+++ b/content/people/sezal-jain.md
@@ -13,7 +13,7 @@ goodreads = ""
 +++
 
   <p class="text-black text-base leading-normal  md:text-xl lg:text-xl md:leading-snug font-light pb-4 md:pb-7">
-    Sezal is a full range engineer, having worked with hardware, web applications and AI algorithms.. Talk to her about anything ranging from data pipelines, large scale logistics solutions, MLOps, AI evals to robotics, autonomous aerial vehicles and strawberry farming.
+    Sezal is a full range engineer, having worked with hardware, web applications and AI algorithms. Talk to her about anything ranging from data pipelines, large scale logistics solutions, MLOps, AI evals to robotics, autonomous aerial vehicles and strawberry farming.
   </p>
 <p class="text-black text-base leading-normal  md:text-xl lg:text-xl md:leading-snug font-light pb-4 md:pb-7">
 When not deep into code, she enjoys exploring different fields and coming up with new ideas to build. An IIT grad, she went on to work in robotics at Carnegie Mellon, and led a healthcare startup tech team before joining nilenso.


### PR DESCRIPTION
## Summary
- fix a typo in Sezal Jain's profile so that the AI sentence ends with one period

## Testing
- `grep -n 'AI algorithms' content/people/sezal-jain.md`

------
https://chatgpt.com/codex/tasks/task_e_684138bb0ba8832a87d4f5101dd3a8c6