### PR TITLE
Add CAIS spotlight homepage banner

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -75,6 +75,36 @@ main {
     min-height: 75vh;
 }
 
+.announcement-banner {
+    background: #111111;
+    border-bottom: 1px solid rgba(255, 61, 132, 0.45);
+    color: var(--nilenso-white);
+    font-size: 0.88rem;
+    line-height: 1.45;
+    padding: 0.7rem 1.5rem;
+    text-align: center;
+}
+
+.announcement-banner a {
+    color: var(--nilenso-white);
+    font-weight: 500;
+    text-decoration: underline;
+    text-decoration-color: var(--nilenso-pink);
+    text-underline-offset: 0.2em;
+}
+
+.announcement-banner a:hover {
+    color: var(--nilenso-pink);
+}
+
+@media (min-width: 768px) {
+    .announcement-banner {
+        font-size: 0.95rem;
+        padding-left: 3rem;
+        padding-right: 3rem;
+    }
+}
+
 h1 {
     font-weight: 500;
     font-size: 1.8rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,9 @@
 
 <body class="antialiased bg-white md:max-w-[1366px] mx-auto w-full font-normal">
 <main>
+    {% block announcement %}
+    {% endblock %}
+
     <header class="py-12 pl-6 pr-8 mg:py-16 lg:py-16 md:px-12 bg-white">
 
         <!-- Mobile Menu -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,17 @@
 {% extends "base.html" %}
 
+{% block announcement %}
+    <aside class="announcement-banner" aria-label="Announcement">
+        <p>
+            🎉 Our
+            <a href="https://www.caisconf.org/program/2026/demos/context-viewer/"
+               target="_blank"
+               rel="noopener noreferrer">context viewer</a> demo
+            earned an industry spotlight at CAIS 2026.
+        </p>
+    </aside>
+{% endblock announcement %}
+
 {% block header %}
     <section class="pt-6 pb-10 px-6 md:py-10 md:px-8 lg:pt-12 lg:pb-16 lg:px-12">
         <div>


### PR DESCRIPTION
## Summary
- add a homepage-only announcement banner for the CAIS 2026 industry spotlight
- link the context viewer text to the CAIS demo page
- add isolated banner styles for easy removal later

## Test
- npm run build